### PR TITLE
Implement the container list endpoint. Add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+test:
+	docker pull busybox:latest
+	go test ./...

--- a/container/containerapi/container.go
+++ b/container/containerapi/container.go
@@ -6,6 +6,26 @@ import (
 	"github.com/cpuguy83/go-docker/container/containerapi/mount"
 )
 
+// Container represents a container
+type Container struct {
+	ID              string `json:"Id"`
+	Names           []string
+	Created         int
+	Path            string
+	Args            []string
+	State           string
+	Image           string
+	ImageID         string
+	Command         string
+	Ports           []NetworkPort
+	Labels          map[string]string
+	HostConfig      *HostConfig
+	NetworkSettings *NetworkSettings
+	Mounts          []MountPoint
+	SizeRootFs      int
+	SizeRw          int
+}
+
 // ContainerInspect is newly used struct along with MountPoint
 type ContainerInspect struct {
 	ID              string `json:"Id"`
@@ -39,6 +59,14 @@ type ContainerInspect struct {
 type NetworkAddress struct {
 	Addr      string
 	PrefixLen int
+}
+
+// NetworkPort represents a network port
+type NetworkPort struct {
+	IP          string
+	PrivatePort int
+	PublicPort  int
+	Type        string
 }
 
 // NetworkSettings exposes the network settings in the api

--- a/container/list.go
+++ b/container/list.go
@@ -1,0 +1,95 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+
+	"github.com/cpuguy83/go-docker/container/containerapi"
+	"github.com/cpuguy83/go-docker/httputil"
+
+	"github.com/cpuguy83/go-docker/version"
+
+	"github.com/pkg/errors"
+)
+
+// ListFilter represents filters to process on the container list.
+type ListFilter struct {
+	Ancestor  []string `json:"ancestor,omitempty"`
+	Before    []string `json:"before,omitempty"`
+	Expose    []string `json:"expose,omitempty"`
+	Exited    []string `json:"exited,omitempty"`
+	Health    []string `json:"health,omitempty"`
+	ID        []string `json:"id,omitempty"`
+	Isolation []string `json:"isolation,omitempty"`
+	IsTask    []string `json:"is-task,omitempty"`
+	Label     []string `json:"label,omitempty"`
+	Name      []string `json:"name,omitempty"`
+	Network   []string `json:"network,omitempty"`
+	Publish   []string `json:"publish,omitempty"`
+	Since     []string `json:"since,omitempty"`
+	Status    []string `json:"status,omitempty"`
+	Volume    []string `json:"volume,omitempty"`
+}
+
+// ListConfig holds the options for listing containers
+type ListConfig struct {
+	All    bool
+	Limit  int
+	Size   bool
+	Filter ListFilter
+}
+
+// ListOption is used as functional arguments to list containers
+// ListOption configure an InspectConfig.
+type ListOption func(config *ListConfig)
+
+// List fetches a list of containers.
+func (s *Service) List(ctx context.Context, opts ...ListOption) ([]containerapi.Container, error) {
+	cfg := ListConfig{
+		Limit: -1,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	withListConfig := func(req *http.Request) error {
+		q := req.URL.Query()
+		q.Add("all", strconv.FormatBool(cfg.All))
+		q.Add("limit", strconv.Itoa(cfg.Limit))
+		q.Add("size", strconv.FormatBool(cfg.Size))
+		filterJSON, err := json.Marshal(cfg.Filter)
+
+		if err != nil {
+			return err
+		}
+		q.Add("filters", string(filterJSON))
+
+		req.URL.RawQuery = q.Encode()
+		return nil
+	}
+
+	var containers []containerapi.Container
+
+	resp, err := httputil.DoRequest(ctx, func(ctx context.Context) (*http.Response, error) {
+		return s.tr.Do(ctx, http.MethodGet, version.Join(ctx, "/containers/json"), withListConfig)
+	})
+	if err != nil {
+		return containers, err
+	}
+
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return containers, nil
+	}
+
+	if err := json.Unmarshal(data, &containers); err != nil {
+		return containers, errors.Wrap(err, "error unmarshalling container json")
+	}
+
+	return containers, nil
+}

--- a/container/list_test.go
+++ b/container/list_test.go
@@ -1,0 +1,126 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestList(t *testing.T) {
+	ctx := context.Background()
+	s := newTestService(t)
+
+	c, err := s.Create(ctx, WithCreateImage("busybox:latest"),
+		WithCreateCmd("/bin/sh", "-c", "trap 'exit 0' SIGTERM; while true; do sleep 0.1; done"),
+	)
+	assert.NilError(t, err)
+
+	defer func() {
+		assert.Check(t, s.Remove(ctx, c.ID(), WithRemoveForce))
+	}()
+
+	err = c.Start(ctx)
+	assert.NilError(t, err)
+
+	containers, err := s.List(ctx)
+	found := false
+	for _, container := range containers {
+		fmt.Printf("\n\nid: %s\n", c.ID())
+		fmt.Printf("\n\nlooking for: %s\n", container.ID)
+		if container.ID == c.ID() {
+			found = true
+			break
+		}
+	}
+
+	assert.Assert(t, found, "expected container to be found but it wasn't")
+}
+
+func TestListLimit(t *testing.T) {
+	ctx := context.Background()
+	s := newTestService(t)
+	n := 4
+
+	for i := 0; i < n; i++ {
+		c, err := s.Create(ctx, WithCreateImage("busybox:latest"),
+			WithCreateCmd("/bin/sh", "-c", "trap 'exit 0' SIGTERM; while true; do sleep 0.1; done"),
+		)
+		assert.NilError(t, err)
+
+		defer func() {
+			assert.Check(t, s.Remove(ctx, c.ID(), WithRemoveForce))
+		}()
+
+		err = c.Start(ctx)
+		assert.NilError(t, err)
+	}
+
+	containers, err := s.List(ctx, func(config *ListConfig) {
+		config.Limit = 2
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, len(containers) == 2, "expected container to be found but it wasn't")
+	assert.Equal(t, containers[0].SizeRootFs, 0, "expected container's SizeRootFs to be a zero value")
+	assert.Assert(t, containers[0].SizeRw == 0, "expected container's SizeRw to be a positive integer")
+
+}
+
+func TestListSize(t *testing.T) {
+	ctx := context.Background()
+	s := newTestService(t)
+	n := 1
+
+	for i := 0; i < n; i++ {
+		c, err := s.Create(ctx, WithCreateImage("busybox:latest"),
+			WithCreateCmd("/bin/sh", "-c", "trap 'exit 0' SIGTERM; while true; do sleep 0.1; done"),
+		)
+		assert.NilError(t, err)
+
+		defer func() {
+			assert.Check(t, s.Remove(ctx, c.ID(), WithRemoveForce))
+		}()
+
+		err = c.Start(ctx)
+		assert.NilError(t, err)
+	}
+
+	containers, err := s.List(ctx, func(config *ListConfig) {
+		config.Limit = 1
+		config.Size = true
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, len(containers) == 1, "expected container to be found but it wasn't")
+	assert.Assert(t, containers[0].SizeRw == 0, "expected container's SizeRw to exist")
+	assert.Assert(t, containers[0].SizeRootFs > 0, "expected container's SizeRootFs to be a positive integer")
+}
+
+func TestListFilter(t *testing.T) {
+	ctx := context.Background()
+	s := newTestService(t)
+	n := 2
+
+	for i := 0; i < n; i++ {
+		c, err := s.Create(ctx,
+			WithCreateImage("busybox:latest"),
+			WithCreateCmd("/bin/sh", "-c", "trap 'exit 0' SIGTERM; while true; do sleep 0.1; done"),
+			WithCreateName(fmt.Sprintf("foobar-%d", i)),
+		)
+		assert.NilError(t, err)
+
+		defer func() {
+			assert.Check(t, s.Remove(ctx, c.ID(), WithRemoveForce))
+		}()
+
+		err = c.Start(ctx)
+		assert.NilError(t, err)
+	}
+
+	containers, err := s.List(ctx, func(config *ListConfig) {
+		config.Filter = ListFilter{Name: []string{"foobar-0"}}
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, len(containers) == 1, "expected container to be %d but received %d", 1, len(containers))
+	assert.Assert(t, containers[0].Names[0] == "/foobar-0")
+}


### PR DESCRIPTION
- Implements the [list](https://docs.docker.com/engine/api/v1.40/#operation/ContainerList) API endpoint.
- Add tests for various list options.
- Add a Makefile to assist with various build tasks and testing prerequisites.