### PR TITLE
image: support loading and pruning images

### DIFF
--- a/image/imageapi/prune.go
+++ b/image/imageapi/prune.go
@@ -1,0 +1,11 @@
+package imageapi
+
+type Prune struct {
+	ImagesDeleted  []DeletedImage
+	SpaceReclaimed int64
+}
+
+type DeletedImage struct {
+	Untagged string
+	Deleted  string
+}

--- a/image/load.go
+++ b/image/load.go
@@ -1,0 +1,46 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/cpuguy83/go-docker/httputil"
+	"github.com/cpuguy83/go-docker/version"
+)
+
+// LoadConfig holds the options for loading images.
+type LoadConfig struct {
+	Quiet bool
+}
+
+// LoadOption is used as functional arguments to list images. LoadOption
+// configure a LoadConfig.
+type LoadOption func(config *LoadConfig)
+
+// Load loads container images.
+func (s *Service) Load(ctx context.Context, tar io.ReadCloser, opts ...LoadOption) error {
+	cfg := LoadConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	withListConfig := func(req *http.Request) error {
+		q := req.URL.Query()
+		q.Add("quiet", strconv.FormatBool(cfg.Quiet))
+		req.URL.RawQuery = q.Encode()
+		req.Body = tar
+		return nil
+	}
+
+	resp, err := httputil.DoRequest(ctx, func(ctx context.Context) (*http.Response, error) {
+		return s.tr.Do(ctx, http.MethodPost, version.Join(ctx, "/images/load"), withListConfig)
+	})
+	if err != nil {
+		return fmt.Errorf("loading images: %w", err)
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/image/load_test.go
+++ b/image/load_test.go
@@ -1,0 +1,33 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os/exec"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestLoad(t *testing.T) {
+	ctx := context.Background()
+	s := newTestService(t)
+
+	// Pull a dummy image that we can export.
+	err := s.Pull(ctx, Remote{
+		Locator: "hello-world",
+		Host:    "docker.io",
+		Tag:     "latest",
+	})
+	assert.NilError(t, err, "expected pulling hello-world to succeed")
+
+	cmd := exec.Command("docker", "image", "save", "hello-world:latest")
+	bundle, err := cmd.CombinedOutput()
+	assert.NilError(t, err, "expected exporting hello-world to succeed")
+
+	err = s.Load(ctx, io.NopCloser(bytes.NewReader(bundle)), func(config *LoadConfig) {
+		config.Quiet = true
+	})
+	assert.NilError(t, err, "expecting load to succeed")
+}

--- a/image/prune.go
+++ b/image/prune.go
@@ -1,0 +1,70 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cpuguy83/go-docker/httputil"
+	"github.com/cpuguy83/go-docker/image/imageapi"
+	"github.com/cpuguy83/go-docker/version"
+)
+
+// PruneFilter represents filters to process on the prune list. See the official
+// docker docs for the meaning of each field
+// https://docs.docker.com/engine/api/v1.41/#operation/ImagePrune
+type PruneFilter struct {
+	Dangling []string `json:"dangling,omitempty"`
+	Label    []string `json:"label,omitempty"`
+	NotLabel []string `json:"label!,omitempty"`
+	Until    []string `json:"until,omitempty"`
+}
+
+// PruneConfig holds the options for pruning images.
+type PruneConfig struct {
+	Filters PruneFilter
+}
+
+// PruneOption is used as functional arguments to prune images. PruneOption
+// configure a PruneConfig.
+type PruneOption func(config *PruneConfig)
+
+// prune prunes container images.
+func (s *Service) Prune(ctx context.Context, opts ...PruneOption) (imageapi.Prune, error) {
+	cfg := PruneConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	withPruneConfig := func(req *http.Request) error {
+		q := req.URL.Query()
+		filterJSON, err := json.Marshal(cfg.Filters)
+		if err != nil {
+			return err
+		}
+		_ = filterJSON
+		q.Add("filters", string(filterJSON))
+		req.URL.RawQuery = q.Encode()
+		return nil
+	}
+
+	resp, err := httputil.DoRequest(ctx, func(ctx context.Context) (*http.Response, error) {
+		return s.tr.Do(ctx, http.MethodPost, version.Join(ctx, "/images/prune"), withPruneConfig)
+	})
+	if err != nil {
+		return imageapi.Prune{}, fmt.Errorf("pruning images: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return imageapi.Prune{}, err
+	}
+	var prune imageapi.Prune
+	if err := json.Unmarshal(data, &prune); err != nil {
+		return imageapi.Prune{}, fmt.Errorf("reading response body: %w", err)
+	}
+	return prune, nil
+}

--- a/image/prune_test.go
+++ b/image/prune_test.go
@@ -1,0 +1,105 @@
+package image
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cpuguy83/go-docker/image/imageapi"
+	"gotest.tools/v3/assert"
+)
+
+func TestPrune(t *testing.T) {
+	ctx := context.Background()
+	s := newTestService(t)
+
+	buildContainers := func(t *testing.T) {
+		buildContainer(t, "test-image:positive", "test-image", "positive=true")
+		buildContainer(t, "test-image:negative", "test-image", "positive=false")
+		// Add a dummy image that should never be discovered in the tests below.
+		// In particualar, this tests that the interaction between Label and
+		// NotLabel filter works as intended.
+		buildContainer(t, "other-image:all", "other-image")
+	}
+	cleanup := func(t *testing.T) {
+		_, err := s.Prune(ctx, func(config *PruneConfig) {
+			config.Filters.Dangling = []string{"false"}
+			config.Filters.Label = []string{"test-image"}
+		})
+		assert.NilError(t, err)
+		_, err = s.Prune(ctx, func(config *PruneConfig) {
+			config.Filters.Dangling = []string{"false"}
+			config.Filters.Label = []string{"other-image"}
+		})
+		assert.NilError(t, err)
+	}
+
+	extract := func(prune imageapi.Prune) []string {
+		var l []string
+		for _, deleted := range prune.ImagesDeleted {
+			if deleted.Untagged != "" {
+				l = append(l, deleted.Untagged)
+			}
+		}
+		sort.Strings(l)
+		return l
+	}
+
+	t.Run("all", func(t *testing.T) {
+		buildContainers(t)
+		defer cleanup(t)
+
+		rep, err := s.Prune(ctx, func(config *PruneConfig) {
+			config.Filters.Dangling = []string{"false"}
+			config.Filters.Label = []string{"test-image"}
+		})
+		assert.NilError(t, err)
+		assert.DeepEqual(t, extract(rep), []string{"test-image:negative", "test-image:positive"})
+	})
+
+	t.Run("positive", func(t *testing.T) {
+		buildContainers(t)
+		defer cleanup(t)
+
+		rep, err := s.Prune(ctx, func(config *PruneConfig) {
+			config.Filters.Dangling = []string{"false"}
+			config.Filters.Label = []string{"positive=true"}
+		})
+		assert.NilError(t, err)
+		assert.DeepEqual(t, extract(rep), []string{"test-image:positive"})
+	})
+
+	t.Run("non-positive", func(t *testing.T) {
+		buildContainers(t)
+		defer cleanup(t)
+
+		rep, err := s.Prune(ctx, func(config *PruneConfig) {
+			config.Filters.Dangling = []string{"false"}
+			config.Filters.Label = []string{"test-image"}
+			config.Filters.NotLabel = []string{"positive=true"}
+		})
+		assert.NilError(t, err)
+		assert.DeepEqual(t, extract(rep), []string{"test-image:negative"})
+	})
+}
+
+// buildContainer builds the container by executing the docker CLI until we have
+// extended the image service to provide the build endpoint.
+func buildContainer(t *testing.T, tag string, labels ...string) {
+	dockerfile := `FROM scratch
+CMD ["hello"]
+`
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0666))
+
+	args := []string{"build", dir, "--tag=" + tag}
+	for _, label := range labels {
+		args = append(args, "--label="+label)
+	}
+
+	rep, err := exec.Command("docker", args...).CombinedOutput()
+	assert.NilError(t, err, string(rep))
+}


### PR DESCRIPTION
Add support for loading and pruning docker images in the image service.

Co-authored-by: Lukas Vogel <vogel@anapaya.net>